### PR TITLE
Allow a Gnuplot version with three components

### DIFF
--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -2009,8 +2009,8 @@ if($Alien::Gnuplot::VERSION < 1.031) {
     die "PDL::Graphics::Gnuplot requires Alien::Gnuplot version 1.031 or higher\n (v$Alien::Gnuplot::VERSION found). You can pull the latest from CPAN.\n";
 }
 
-our $gnuplot_dep_v = 4.6; # Versions below this are deprecated.
-our $gnuplot_req_v = 4.4; # Versions below this are not supported.
+our $gnuplot_dep_v = 4.006; # Versions below this are deprecated.
+our $gnuplot_req_v = 4.004; # Versions below this are not supported.
 
 # Compile time config flags...
 our $check_syntax = 0;
@@ -2022,7 +2022,8 @@ our $debug_echo = 0;                              # If set, mock up Losedows hal
 our $VERSION = '2.013';
 $VERSION = eval $VERSION;
 
-our $gp_version = undef;   # eventually gets the extracted gnuplot(1) version number.
+our $gp_version = undef;    # eventually gets the extracted gnuplot(1) version number.
+our $gp_numversion = undef; # which is here converted to a float
 
 my $did_warn_non_numeric_patchlevel; # whether we already warned about this
 
@@ -6217,7 +6218,7 @@ our $_OptionEmitters = {
 	#### This is because some "withs" (e.g. "lines") must have dt specifiers for the correct behavior,
 	#### but other "withs" (e.g. "labels") barf if dt is specified.
     'dt' => sub { my($k,$v,$h, $w) = @_;
-		  return "" unless($gp_version >= 5.0);
+		  return "" unless($gp_numversion >= 5.0);
 		  return "" if(($v//"") eq 'INVALID');
 		  unless($v) {
 		      if($w->{options}->{terminal} =~ m/dashed/) {
@@ -7489,11 +7490,13 @@ EOM
 ##############################
 # Parse version number.  If the version or pl changed, try reloading Alien::Gnuplot
 # to get them in sync.
-	if( $s =~ m/Version (\d+\.\d+) (patchlevel (\w+))?/i ) {
+	if( $s =~ m/Version ((\d+)\.(\d+)(\.(\d+))?) (patchlevel (\w+))?/i ) {
 	    $gp_version = $1;
-	    $gp_pl = $3;
+            $gp_numversion = $2 + 0.001*$3 + 0.000001*$5;
+	    $gp_pl = $7;
 	    $this->{gp_version} = $1;
-	    $this->{gp_pl} = $3;
+            $this->{gp_numversion} = $gp_numversion;
+	    $this->{gp_pl} = $7;
 	} else {
 
 	    # Something went wrong with i/o.  See if the process still exists.
@@ -7546,12 +7549,12 @@ EOM
 	    }
             
             # On windows, gnuplot versions 4.6.5 and older echo back commands.
-            if ( $gp_version <= '4.6' && $gp_pl <= 5 ) {
+            if ( $gp_numversion <= '4.006' && $gp_pl <= 5 ) {
                 $echo_eating = 1;
             }
 	}
 
-	if( $gp_version < $gnuplot_dep_v  and  !$PDL::Graphics::Gnuplot::deprecated_this_session ) {
+	if( $gp_numversion < $gnuplot_dep_v  and  !$PDL::Graphics::Gnuplot::deprecated_this_session ) {
             $PDL::Graphics::Gnuplot::deprecated_this_session = 1;
 	    unless($ENV{GNUPLOT_DEPRECATED}){
 	    carp <<"EOM";


### PR DESCRIPTION
PDL-Graphics-Gnuplot fails hard with recent Gnuplot 5.4.1, since it assumes that the version number has only two components (and is a float). Here's a fix. In order to still allow version comparison, a variable $gp_numversion is introduced which becomes e.g. 5.004001 ...