### PR TITLE
Add new method pause_until_close

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+«NEXT»
+- Add pause_until_close method.
+
 2.016 2021-04-10
 - some build improvements plus better test-reporting
 

--- a/README.pod
+++ b/README.pod
@@ -2072,6 +2072,10 @@ scaled down using C<PDL::Transform>.  Fixed font sized, line widths,
 and point sizes are autoscaled -- but you must handle variable ones
 explicitly.
 
+Antialiasing is done in the gamma=2.2 approximation, to match the sRGB
+coding that most pixel image files use.  (See PDL::Transform::Color
+for more information).
+
 =back
 
 For a brief description of the terminal options that any one device supports,
@@ -2494,6 +2498,22 @@ The routine will call markup after each click.
 =back
 
 =back
+
+=cut
+=pod
+
+=head2 pause_until_close
+
+=for usage
+
+  $w->pause_until_close;
+
+=for ref
+
+Wait until the active interactive plot window is closed (e.g., by clicking the
+close button, hitting the close key-binding which defaults to C<q>).
+
+C<pause_until_close> blocks execution until the close event.
 
 =cut
 =pod

--- a/examples/pause-until-close.pl
+++ b/examples/pause-until-close.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/env perl
+# PODNAME: pause-until-close
+# ABSTRACT: Example script demonstrating the pause_until_close functionality
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use strict;
+use warnings;
+
+use PDL;
+use PDL::Graphics::Gnuplot;
+use PDL::Constants qw(PI);
+use IO::Interactive qw(is_interactive);
+
+sub main {
+	die "Please run interactively" unless is_interactive;
+
+	my $w = gpwin();
+	my $xrange = [ -2*PI, 2*PI ];
+	my $x = zeroes(1e3)->xlinvals(@$xrange);
+
+	my $po = { xrange => $xrange };
+	$w->plot( with => 'lines', $x, sin($x), $po );
+	$w->pause_until_close;
+	print "Closed plot\n";
+
+	$w->plot( with => 'lines', $x, cos($x), $po );
+	print "Continuing without waiting\n";
+
+	print "Press <Return> to continue\n";
+	my $read_line = <>;
+	return;
+}
+
+main;
+=pod
+
+=head1 Description
+
+In order to demonstrate the usage of the C<pause_until_close> method, this
+example plots the C<sin> function between -2*pi and 2*pi, then waits for the
+user to close the plot window. After the window is closed, it plots the C<cos>
+function also between -2*pi and 2*pi.
+
+=head1 Octave equivalent
+
+The C<pause_until_close> method is roughly equivalent to the C<waitfor>
+function in Octave.
+
+  H = axes();
+  xrange = [ -2*pi, 2*pi ];
+  x = linspace(xrange(1), xrange(2), 1e3);
+  
+  plot(H, x, sin(x)); xlim(H, xrange);
+  waitfor(H);
+  disp('Closed plot');
+  
+  plot(x, cos(x)); xlim(xrange);
+  disp('Continuing without waiting');
+
+=cut

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -4727,6 +4727,37 @@ no PDL::NiceSlice;
 
 }
 
+=pod
+
+=head2 pause_until_close
+
+=for usage
+
+  $w->pause_until_close;
+
+=for ref
+
+Wait until the active interactive plot window is closed (e.g., by clicking the
+close button, hitting the close key-binding which defaults to C<q>).
+
+C<pause_until_close> blocks execution until the close event.
+
+=cut
+
+sub pause_until_close {
+    my $this = shift;
+
+    barf "pause_until_close: $this->{terminal} terminal doesn't support mousing\n"
+        unless($this->{mouse});
+
+    _printGnuplotPipe($this, 'main', <<'EOC');
+pause mouse close
+EOC
+    _checkpoint($this, "main", {notimeout=>1});
+
+    return;
+}
+
 ######################################################################
 ######################################################################
 ######################################################################


### PR DESCRIPTION
This waits for a close event from Gnuplot. This allows for interactively
waiting for a plot window to be closed.

---

This was a request from a user on a `#perl` IRC channel.

I'm open to changes in the method name. So far I have only tested on Linux, but this uses an entirely built-in Gnuplot feature.