### PR TITLE
Fix for pdfcairo terminal not writing to file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+«NEXT»
+- Fix for pdfcairo terminal not writing to file.
+
 2.017 2021-05-28
 - Add pause_until_close method.
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,3 +8,4 @@ MANIFEST			This list of files
 MANIFEST.SKIP
 README.pod
 t/plot.t
+t/pdfcairo-output.t

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -7651,12 +7651,7 @@ sub _killGnuplot {
 	    $z = waitpid($goner,0);
 
 	} else {
-	    ### Use HUP as the Mr. Nice Guy solution.  
-	    ### This is to avoid a problem of error message jabbering in
-	    ### perl processes that use fork() and IPC. 
-	    #_printGnuplotPipe($this,$suffix,"exit\n");
-
-	    kill 'HUP', $goner;
+	    _printGnuplotPipe($this,$suffix,"exit\n");
 
 	    # Give it 2 seconds to quit, then interrupt it again.
 	    # If that doesn't work kill it dead.

--- a/t/pdfcairo-output.t
+++ b/t/pdfcairo-output.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+use PDL::Graphics::Gnuplot qw(gpwin);
+use File::Temp qw(tempfile);
+use PDL;
+
+# Testing 'pdfcairo' terminal separately because Gnuplot only writes the PDF
+# when plotting is done.
+
+if( $PDL::Graphics::Gnuplot::valid_terms->{pdfcairo} ) {
+    plan tests => 1;
+} else {
+    plan skip_all => 'No terminal pdfcairo';
+}
+
+my (undef, $testoutput) = tempfile('pdl_graphics_gnuplot_test_pdfcairo_XXXXXXX',
+    SUFFIX => '.pdf');
+
+my $x = zeroes(50)->xlinvals(0, 7);
+my $w = gpwin("pdfcairo", output => $testoutput);
+$w->plot(with => 'lines', $x, $x->sin);
+$w->close;
+ok -s $testoutput, 'File has size';
+
+unlink($testoutput) or warn "\$!: $!";
+
+done_testing;


### PR DESCRIPTION
Since Gnuplot does not write the PDF file for the `pdfcairo` terminal
until plotting is finished, the `pdfcairo` terminal behaves different
from other terminals (e.g., `png`, `pngcairo`).

Reverts the code in <https://github.com/PDLPorters/PDL-Graphics-Gnuplot/commit/5eaea67c92a119dc907f43e03fef522a18940d72>
where it sends the `HUP` signal to Gnuplot instead of sending the `exit`
command in order to cleanly exit Gnuplot.

Fixes issue reported by Luis Mochan at <https://sourceforge.net/p/pdl/mailman/message/37333776/>.
