### PR TITLE
Set XDG_RUNTIME_DIR variable to temporary directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+- Set XDG_RUNTIME_DIR environment variable if not set. Required for some
+  terminals (Qt).
+
 2.019 2021-08-16
 - end_multi only calls close if not a display
 - when Qt and multiplot, need to send extra command to make window close

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -66,6 +66,7 @@ WriteMakefile(
 	    'Storable'            => 0,
 	    'IPC::Open3'          => 0,
 	    'IO::Select'          => 0,
+	    'File::Temp'          => '0.19',
 	    'Time::HiRes'         => 0,
 	    'Safe::Isa'           => 0
     },

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -1999,6 +1999,7 @@ use IPC::Open3;
 use IPC::Run;
 use IO::Select;
 use Symbol qw(gensym);
+use File::Temp ();
 use Time::HiRes qw(gettimeofday tv_interval);
 use Safe::Isa;
 use Carp;
@@ -7465,6 +7466,12 @@ sub _startGnuplot
     my $in  = gensym();
     my $err = gensym();
 
+    my $XDG_RUNTIME_DIR_global = $ENV{XDG_RUNTIME_DIR};
+    local $ENV{XDG_RUNTIME_DIR} = $XDG_RUNTIME_DIR_global;
+    if( exists $ENV{DISPLAY} && ! $XDG_RUNTIME_DIR_global ) {
+        $this->{"_XDG_RUNTIME_DIR-tempdir-$suffix"} = File::Temp->newdir();
+        $ENV{XDG_RUNTIME_DIR} = '' . $this->{"_XDG_RUNTIME_DIR-tempdir-$suffix"};
+    }
     my $pid = open3($in,$err,$err, $Alien::Gnuplot::executable, @gnuplot_options);
 
     unless($pid) {


### PR DESCRIPTION
If this environment variable is not set, some Gnuplot terminals will
fail. This bug was reported by Ingo Schmid on the pdl-devel mailing list
by running `sudo cpanm PDL::Graphics::Simple` which failed some tests
with the error:

> Gnuplot error: "QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to
> '/tmp/runtime-root'" while sending final multiplot command

To work around this, locally set the variable to a temporary directory
before opening the Gnuplot process.

---

To test this PR:

```dockerfile
# ( BR=master; docker build --build-arg=BRANCH=$BR -t pggnuplot:$BR . )
# ( BR=set-xdg_runtime_dir; docker build --build-arg=BRANCH=$BR -t pggnuplot:$BR . )
FROM perl:latest

RUN apt-get update && apt-get install -y gnuplot-qt xvfb

RUN cpanm -nq PDL

RUN xvfb-run -a cpanm --installdeps -q PDL::Graphics::Gnuplot

ARG BRANCH
RUN xvfb-run -a cpanm --verbose https://github.com/PDLPorters/PDL-Graphics-Gnuplot.git@$BRANCH

RUN xvfb-run -a cpanm --verbose PDL::Graphics::Simple;
```
