### PR TITLE
Unset badflag for 'aa' (anti-aliasing) option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+- Fix so that 'aa' option does not pass badflag to `wpic`.
 2.021 2022-03-01
 - add demo for use by PDL 2.077+
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 - Fix so that 'aa' option does not pass badflag to `wpic`.
+- Check if terminal image format I/O is available when using 'aa'.
 2.021 2022-03-01
 - add demo for use by PDL 2.077+
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -10,3 +10,4 @@ MANIFEST.SKIP
 README.pod
 t/pdfcairo-output.t
 t/plot.t
+t/aa.t

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -2386,7 +2386,7 @@ FOO
 	    }
 
 	    ### Terminals that support anti-aliasing all broadcast their format so that rpic can handle them.
-	    if( defined $termTab->{terminal}->{image_format}) {
+	    if( defined $termTab->{$terminal}->{image_format}) {
 		$this->{image_format}= $termTab->{$terminal}->{image_format};
 	    } else {
 		delete($this->{image_format});
@@ -2448,6 +2448,10 @@ sub close
     restart($this);
     if(defined $this->{aa} && $this->{aa} && $this->{aa} != 1 && $this->{aa_ready}) {
 	eval "use PDL::Transform; use PDL::IO::Pic;";  # load when needed
+	unless( rpiccan($this->{image_format}) and wpiccan($this->{image_format})  ) {
+		carp "Can not read/write $this->{image_format} for anti-aliasing. Skipping aa operation.";
+		return;
+	}
 	my $im = rpic($this->{options}->{output},{FORMAT=>$this->{image_format}});
 	if($im->ndims==3) {
 	    $im = $im->mv(0,-1);
@@ -7066,7 +7070,10 @@ for my $k(keys %$termTabSource) {
 				 undef, # This gets filled in on first use in the constructor.
 				 "$k terminal options"
 			   ],
-		       default_output=> $v->{default_output}
+		       default_output=> $v->{default_output},
+		       ( exists $v->{image_format}
+			       ? ( image_format => $v->{image_format} )
+			       : () ),
                      };
 }
 

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -2455,6 +2455,7 @@ sub close
 	# gamma-correct before scaling, and put back after.
 	my $imf = ((float $im)/255.0)->clip(0,1) ** 2.2;
 	$imf = $imf->match( [ $im->dim(0)/$this->{aa}, $im->dim(1)/$this->{aa} ], {method=>'h',blur=>0.5});
+	$imf->check_badflag;
 	$im = byte(($imf ** (1/2.2)) * 255);
 	if($im->ndims==3){
 	    $im = $im->mv(-1,0);

--- a/t/aa.t
+++ b/t/aa.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+
+use PDL::Graphics::Gnuplot qw(gpwin);
+use File::Temp qw(tempfile);
+use PDL;
+
+
+my @terms_with_aa = map {
+  my $tab = $_;
+  grep exists $tab->{$_}{opt}[0]{aa}, keys %$tab
+} $PDL::Graphics::Gnuplot::termTab;
+
+my @valid_terms = grep $PDL::Graphics::Gnuplot::valid_terms->{$_}, @terms_with_aa;
+
+if( @valid_terms ) {
+  plan tests => scalar @valid_terms;
+} else {
+  plan skip_all => 'No terminals with anti-aliasing';
+}
+
+for my $term (sort @valid_terms) {
+  subtest "Terminal $term" => sub {
+    my ($suffix) = $PDL::Graphics::Gnuplot::termTab->{$term}{default_output} =~ /(\.[^.]+)$/;
+
+    ok $suffix, 'have suffix';
+
+    my (undef, $testoutput) = tempfile('pdl_graphics_gnuplot_test_aa_XXXXXXX',
+      SUFFIX => $suffix);
+
+    my $x = zeroes(50)->xlinvals(0, 7);
+    my $w = gpwin($term, output => $testoutput, aa => 2);
+    $w->plot(with => 'lines', $x, $x->sin);
+    $w->close;
+    ok -s $testoutput, 'File has size';
+
+    unlink($testoutput) or warn "\$!: $!";
+  };
+}
+
+done_testing;


### PR DESCRIPTION
Otherwise the call to `wpic` will fail while processing the bad value.

Adds a test of the terminals that support the 'aa' option.
