### PR TITLE
Fix mismatch in how Gnuplot is found during configure and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           target-setup-perl: false
           target-install-dist-perl-deps: true
+          dist-perl-deps-configure: Alien::Gnuplot
           target-test-release-testing: true
           target-test: true
           test-enable-release-testing: ${{ matrix.release-test }}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+- Add Alien::Gnuplot as a configure-time dependency. Fixes #92.
 2.023 2023-01-29
 - Fix over-enthusiastic code tidying - thanks @zmughal
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,23 +3,7 @@ use warnings;
 use ExtUtils::MakeMaker 6.48;
 
 # make sure we can run gnuplot before continuing
-{
-    unless(`gnuplot -V`)
-    {
-        print STDERR <<EOM;
-
-Error: "$!"
-
-I tried to execute 'gnuplot' and it didn't work. Since this module is an is an
-interface to Gnuplot, it must be installed for the module to be useful. Install
-Gnuplot to continue. Use your package manager, or download the source from
-http://www.gnuplot.info
-EOM
-
-        exit 0;
-    }
-}
-
+use Alien::Gnuplot;
 
 sub MY::libscan {
     package MY;
@@ -56,6 +40,7 @@ WriteMakefile(
     MIN_PERL_VERSION          => 5.006,
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => '6.64', # TEST_REQUIRES
+        'Alien::Gnuplot'      => 0,
     },
     PREREQ_PM => { 
             'Alien::Gnuplot'      => 0,


### PR DESCRIPTION
This adds `Alien::Gnuplot` as a configure-time dependency so that it
finds the `gnuplot` binary the same way at configure-time that it
already does at runtime.  Since `Alien::Gnuplot` already checks for a
working Gnuplot, `Makefile.PL` does not need to do this.

This allows for overriding via the `GNUPLOT_BINARY` environment variable
(e.g., for testing multiple versions of Gnuplot).

Fixes <https://github.com/PDLPorters/PDL-Graphics-Gnuplot/issues/92>.
