### PR TITLE
Split version checking from `use Alien::Gnuplot`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+- Split version checking from `use Alien::Gnuplot` line for easier downstream
+  packaging. Fixes #98.
+
 2.024 2023-03-30
 - Add Alien::Gnuplot as a configure-time dependency. Fixes #92 - thanks @zmughal
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ WriteMakefile(
         'Alien::Gnuplot'      => 0,
     },
     PREREQ_PM => { 
-            'Alien::Gnuplot'      => 0,
+	    'Alien::Gnuplot'      => '1.031',
 	    'PDL'                 => 0,
 	    'PDL::Transform::Color' => 0,
 	    'IPC::Run'            => 0,

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -2010,7 +2010,7 @@ use Time::HiRes qw(gettimeofday tv_interval);
 use Safe::Isa;
 use Carp;
 
-use Alien::Gnuplot 4.4;  # Ensure gnuplot exists and is recent, and get ancillary info about it.
+use Alien::Gnuplot;
 if($Alien::Gnuplot::VERSION < 1.031) {
     # Have to check explicitly since we use the version hack to check the *gnuplot* version.
     die "PDL::Graphics::Gnuplot requires Alien::Gnuplot version 1.031 or higher\n (v$Alien::Gnuplot::VERSION found). You can pull the latest from CPAN.\n";
@@ -2018,6 +2018,8 @@ if($Alien::Gnuplot::VERSION < 1.031) {
 
 our $gnuplot_dep_v = 4.006; # Versions below this are deprecated.
 our $gnuplot_req_v = 4.004; # Versions below this are not supported.
+# Ensure gnuplot exists and is recent, and get ancillary info about it.
+Alien::Gnuplot->VERSION('4.4');
 
 # Compile time config flags...
 our $check_syntax = 0;


### PR DESCRIPTION
in order to make downstream packaging easier.

This works around dependency scanning code that assumes the standard
semantics where a version-like string in that location refers to the
version of the Perl module that is stored in the package variable
`$VERSION`.

In particular, this is what `rpmbuild` does via the `perl-generators`
plugin per <https://github.com/jplesnik/generators/blob/1.16/template/bin/perl.req#L240>.

Fixes <https://github.com/PDLPorters/PDL-Graphics-Gnuplot/issues/98>.
