### PR TITLE
Set encoding to fix pod2man errors.

### DIFF
--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -69,6 +69,8 @@
 # PDL::Options in other circumstances.
 #
 
+=encoding UTF-8
+
 =head1 NAME
 
 PDL::Graphics::Gnuplot - Gnuplot-based plotting for PDL


### PR DESCRIPTION
The lintian QA tool reported pod2man errors for the Debian package build:
```
POD ERRORS
       Hey! The above document had some coding errors, which are explained below:

       Around line 307:
           Non-ASCII character seen before =encoding in '2Ï€'. Assuming CP1252
```
This is fixed by using `=encoding UTF-8` for '2π'.